### PR TITLE
fixed launch script to work with node v10.9.0

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -7,4 +7,4 @@ npm run build
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
 # exec node_modules/.bin/hubot --name "penfold" "$@"
-exec coffee --nodejs --debug node_modules/.bin/hubot --name "penfold" "$@"
+exec coffee --nodejs --inspect node_modules/.bin/hubot --name "penfold" "$@"


### PR DESCRIPTION
node v10.9.0 deprecated --debug, replaced it with --inspect
see https://nodejs.org/api/deprecations.html#deprecations_dep0062_node_debug